### PR TITLE
Non-interactive mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 .idea/
 data/
 schema-deletion-tool
+confluent-schema_registry-cleanup

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,10 @@ func run(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	nonInteractive, err := cmd.Flags().GetBool("yes")
+	if err != nil {
+		return err
+	}
 	ctx, err := pkg.NewContext(configFile)
 	if err != nil {
 		return err
@@ -39,7 +43,7 @@ func run(cmd *cobra.Command, _ []string) error {
 	ctx.Topics = topics
 
 	// Traverse all clusters in the current environment and prompt for credentials.
-	err = pkg.ListClusters(ctx)
+	err = pkg.ListClusters(ctx, nonInteractive)
 	if err != nil {
 		return err
 	}
@@ -57,11 +61,11 @@ func run(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Prompt users to delete schemas they want to soft/hard delete.
-	selection, err := pkg.SelectDeletionCandidates(schemas, activeSchemas)
+	selection, err := pkg.SelectDeletionCandidates(schemas, activeSchemas, nonInteractive)
 	if err != nil {
 		return err
 	}
-	err = pkg.DeleteSchemas(selection)
+	err = pkg.DeleteSchemas(selection, nonInteractive)
 	if err != nil {
 		return err
 	}
@@ -79,6 +83,7 @@ func Execute() {
 	rootCmd.Flags().StringP("subject", "V", "", "Subject to clean up schemas from.")
 	rootCmd.Flags().Bool("all", false, "Clean up all eligible subjects.")
 	rootCmd.Flags().String("config-file", "", "Path to config file containing credentials for Kafka clusters.")
+	rootCmd.Flags().BoolP("yes", "y", false, "[DANGER] Don't prompt for user input and agree to hard-delete all prompted schemas.")
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/pkg/consumer.go
+++ b/pkg/consumer.go
@@ -113,8 +113,7 @@ func checkIfReachesOffsets(endOffsets, offsets map[int32]kafka.Offset, partition
 		if !ok {
 			val = -1
 		}
-		endVal, _ := endOffsets[i]
-		if val < endVal {
+		if val < endOffsets[i] {
 			return false
 		}
 	}


### PR DESCRIPTION
Added a non-interactive mode, where all user input prompts are skipped and eligible schemas are deleted. Useful in automation.

`confluent schema-registry cleanup --yes --config-file config.conf --subject <subject_name>`