### PR TITLE
DGS-24644: Fix scan hang on offset gaps; protect unscannable topics from deletion

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -180,6 +180,7 @@ func runDelete(cmd *cobra.Command, _ []string) error {
 	fromFile, _ := cmd.Flags().GetString("from-file")
 	mode, _ := cmd.Flags().GetString("mode")
 	force, _ := cmd.Flags().GetBool("force")
+	allowUnverified, _ := cmd.Flags().GetBool("allow-unverified")
 
 	if platformFlag == "cp" && configFile == "" {
 		return errors.New("--config-file is required when --platform=cp")
@@ -205,6 +206,10 @@ func runDelete(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	if err := failIfUnverified(manifest.UnverifiedTopics, allowUnverified); err != nil {
+		return err
+	}
+
 	platform, err := createPlatform(platformFlag, configFile, "", "", "")
 	if err != nil {
 		return err
@@ -212,6 +217,26 @@ func runDelete(cmd *cobra.Command, _ []string) error {
 
 	fmt.Printf("Loaded manifest with %d candidate(s) (generated %s)\n", len(manifest.Candidates), manifest.GeneratedAt)
 	return pkg.ExecuteDeletion(manifest.Candidates, platform, softDelete, hardDelete, force)
+}
+
+// failIfUnverified blocks deletion from a manifest produced by an incomplete
+// scan unless --allow-unverified is set. --force deliberately does not bypass
+// this: automation routinely passes --force, so deleting from a partial scan
+// must be its own explicit opt-in.
+func failIfUnverified(unverifiedTopics []string, allowUnverified bool) error {
+	if len(unverifiedTopics) == 0 {
+		return nil
+	}
+	fmt.Printf("%sManifest lists %d topic(s) that could not be scanned; their schema usage is unverified:%s\n",
+		pkg.RED, len(unverifiedTopics), pkg.RESET)
+	for _, t := range unverifiedTopics {
+		fmt.Printf("  - %s\n", t)
+	}
+	if !allowUnverified {
+		return errors.New("refusing to delete from a manifest with unverified topics; re-scan those topics, or pass --allow-unverified to delete the verified-safe schemas anyway")
+	}
+	fmt.Printf("%s--allow-unverified set: proceeding with deletion of verified-safe schemas.%s\n", pkg.YELLOW, pkg.RESET)
+	return nil
 }
 
 func createPlatform(platformFlag, configFile, srURL, srAPIKey, srAPISecret string) (pkg.Platform, error) {
@@ -480,6 +505,7 @@ Deletion modes:
 	}
 	deleteCmd.Flags().String("from-file", "", "Path to manifest file from scan (required).")
 	deleteCmd.Flags().String("mode", "soft", "Deletion mode: 'soft', 'hard', or 'full'.")
+	deleteCmd.Flags().Bool("allow-unverified", false, "Delete verified-safe schemas even when the manifest has unverified topics (an incomplete scan). Not bypassed by --force.")
 	deleteCmd.MarkFlagRequired("from-file")
 
 	rootCmd.AddCommand(scanCmd, deleteCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -389,9 +389,14 @@ func scanTopicsForActiveSchemas(topics []pkg.TopicWithClusterInfo, platform pkg.
 func mergeActiveSchemas(results []scanResult) (map[int32]int, []string) {
 	activeSchemas := make(map[int32]int)
 	var failedTopics []string
+	seenFailed := make(map[string]bool)
 	for _, r := range results {
 		if r.err != nil {
-			failedTopics = append(failedTopics, r.topic)
+			// The same topic can fail in more than one cluster; report it once.
+			if !seenFailed[r.topic] {
+				seenFailed[r.topic] = true
+				failedTopics = append(failedTopics, r.topic)
+			}
 			continue
 		}
 		for k, v := range r.schemas {
@@ -416,7 +421,7 @@ func printCandidateSummary(candidates []pkg.DeletionCandidate) {
 	}
 }
 
-func Execute() {
+func newRootCmd() *cobra.Command {
 	var rootCmd = &cobra.Command{
 		Use:   "confluent schema-registry cleanup",
 		Short: "Schema deletion tool - discover and delete unused schemas",
@@ -478,8 +483,11 @@ Deletion modes:
 	deleteCmd.MarkFlagRequired("from-file")
 
 	rootCmd.AddCommand(scanCmd, deleteCmd)
+	return rootCmd
+}
 
-	if err := rootCmd.Execute(); err != nil {
+func Execute() {
+	if err := newRootCmd().Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,9 +115,25 @@ func runScan(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Scan topics for active schema IDs
-	activeSchemas, err := scanTopicsForActiveSchemas(topicsWithCluster, platform, ctx, workers)
+	activeSchemas, failedTopics, err := scanTopicsForActiveSchemas(topicsWithCluster, platform, ctx, workers)
 	if err != nil {
 		return err
+	}
+
+	scannedTopics := make([]string, len(topicsWithCluster))
+	for i, t := range topicsWithCluster {
+		scannedTopics[i] = t.Topic
+	}
+
+	// Subjects tied to a topic we couldn't scan have unverifiable usage; block
+	// them so a partial scan can never delete a schema that is still in use.
+	unverifiedSubjects := pkg.SubjectsForFailedTopics(failedTopics, subjects, scannedTopics, strategy)
+	if len(failedTopics) > 0 {
+		fmt.Printf("\n%s%d topic(s) could not be scanned; %d subject(s) tied to them will be marked unverified and excluded from deletion:%s\n",
+			pkg.YELLOW, len(failedTopics), len(unverifiedSubjects), pkg.RESET)
+		for _, t := range failedTopics {
+			fmt.Printf("  - %s\n", t)
+		}
 	}
 
 	// Run safety analysis
@@ -128,6 +144,7 @@ func runScan(cmd *cobra.Command, _ []string) error {
 	}
 
 	candidates = pkg.CheckCompatibility(candidates, platform)
+	candidates = pkg.MarkUnverified(candidates, unverifiedSubjects)
 
 	if len(candidates) == 0 {
 		fmt.Println("No unused schemas found.")
@@ -138,16 +155,13 @@ func runScan(cmd *cobra.Command, _ []string) error {
 
 	// Write manifest if output specified
 	if outputFile != "" {
-		scannedTopics := make([]string, len(topicsWithCluster))
-		for i, t := range topicsWithCluster {
-			scannedTopics[i] = t.Topic
-		}
 		return pkg.WriteManifest(outputFile, candidates, pkg.ManifestOptions{
-			Platform:        platformFlag,
-			Strategy:        strategy,
-			ScannedTopics:   scannedTopics,
-			ScannedClusters: ctx.Clusters,
-			ActiveSchemaIDs: activeSchemas,
+			Platform:         platformFlag,
+			Strategy:         strategy,
+			ScannedTopics:    scannedTopics,
+			ScannedClusters:  ctx.Clusters,
+			ActiveSchemaIDs:  activeSchemas,
+			UnverifiedTopics: failedTopics,
 		})
 	}
 
@@ -285,9 +299,22 @@ func setupContext(platform pkg.Platform, platformFlag, configFile string, force 
 	return ctx, ctx.SetClusters(clusterIDs, force)
 }
 
-func scanTopicsForActiveSchemas(topics []pkg.TopicWithClusterInfo, platform pkg.Platform, ctx *pkg.Context, workers int) (map[int32]int, error) {
+// scanResult is the outcome of scanning a single topic.
+type scanResult struct {
+	schemas map[int32]int
+	err     error
+	topic   string
+	cluster string
+}
+
+// scanTopicsForActiveSchemas scans every topic and returns the merged active
+// schema IDs plus the names of topics that could not be scanned. Per-topic
+// failures do not abort the run; callers must treat schemas tied to the returned
+// failedTopics as unverified. A non-nil error is only returned for setup
+// failures that prevent scanning entirely (e.g. cluster endpoint resolution).
+func scanTopicsForActiveSchemas(topics []pkg.TopicWithClusterInfo, platform pkg.Platform, ctx *pkg.Context, workers int) (map[int32]int, []string, error) {
 	if len(topics) == 0 {
-		return make(map[int32]int), nil
+		return make(map[int32]int), nil, nil
 	}
 
 	// Resolve endpoints per cluster (cache to avoid repeated calls)
@@ -296,19 +323,13 @@ func scanTopicsForActiveSchemas(topics []pkg.TopicWithClusterInfo, platform pkg.
 		if _, ok := endpoints[topic.ClusterID]; !ok {
 			endpoint, err := platform.DescribeCluster(topic.ClusterID)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			endpoints[topic.ClusterID] = endpoint
 		}
 	}
 
 	// Scan topics concurrently
-	type scanResult struct {
-		schemas map[int32]int
-		err     error
-		topic   string
-	}
-
 	results := make(chan scanResult, len(topics))
 	sem := make(chan struct{}, workers)
 
@@ -322,46 +343,57 @@ func scanTopicsForActiveSchemas(topics []pkg.TopicWithClusterInfo, platform pkg.
 			creds := ctx.Credentials[t.ClusterID]
 			ccfg, err := platform.CreateConsumerConfig(t.ClusterID, creds)
 			if err != nil {
-				results <- scanResult{err: err, topic: t.Topic}
+				results <- scanResult{err: err, topic: t.Topic, cluster: t.ClusterID}
 				return
 			}
 			if err = ccfg.SetKey("bootstrap.servers", endpoints[t.ClusterID]); err != nil {
-				results <- scanResult{err: err, topic: t.Topic}
+				results <- scanResult{err: err, topic: t.Topic, cluster: t.ClusterID}
 				return
 			}
 
 			consumer, err := pkg.CreateConsumerFromConfig(ccfg)
 			if err != nil {
-				results <- scanResult{err: err, topic: t.Topic}
+				results <- scanResult{err: err, topic: t.Topic, cluster: t.ClusterID}
 				return
 			}
 			defer consumer.Close()
 
 			topicSchemas, err := pkg.ScanActiveSchemas(consumer, t.Topic)
-			results <- scanResult{schemas: topicSchemas, err: err, topic: t.Topic}
+			results <- scanResult{schemas: topicSchemas, err: err, topic: t.Topic, cluster: t.ClusterID}
 		}(topic)
 	}
 
-	// Collect results
-	activeSchemas := make(map[int32]int)
-	var firstErr error
+	// Collect every result before deciding. A single unscannable topic must not
+	// discard the work done for the others, and the user should see all failures
+	// at once instead of fixing them one re-run at a time.
+	collected := make([]scanResult, 0, len(topics))
 	for i := 0; i < len(topics); i++ {
 		r := <-results
 		if r.err != nil {
-			if firstErr == nil {
-				firstErr = fmt.Errorf("error scanning topic %s: %w", r.topic, r.err)
-			}
+			fmt.Printf("%swarning: failed to scan topic %s (cluster %s): %v%s\n", pkg.YELLOW, r.topic, r.cluster, r.err, pkg.RESET)
+		}
+		collected = append(collected, r)
+	}
+
+	activeSchemas, failedTopics := mergeActiveSchemas(collected)
+	return activeSchemas, failedTopics, nil
+}
+
+// mergeActiveSchemas OR-merges per-topic schema results and returns the names of
+// topics that failed to scan.
+func mergeActiveSchemas(results []scanResult) (map[int32]int, []string) {
+	activeSchemas := make(map[int32]int)
+	var failedTopics []string
+	for _, r := range results {
+		if r.err != nil {
+			failedTopics = append(failedTopics, r.topic)
 			continue
 		}
 		for k, v := range r.schemas {
 			activeSchemas[k] = activeSchemas[k] | v
 		}
 	}
-
-	if firstErr != nil {
-		return nil, firstErr
-	}
-	return activeSchemas, nil
+	return activeSchemas, failedTopics
 }
 
 func printCandidateSummary(candidates []pkg.DeletionCandidate) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/confluentinc/schema-deletion-tool/pkg"
 	"github.com/spf13/cobra"
@@ -22,6 +23,7 @@ func runScan(cmd *cobra.Command, _ []string) error {
 	outputFile, _ := cmd.Flags().GetString("output")
 	force, _ := cmd.Flags().GetBool("force")
 	workers, _ := cmd.Flags().GetInt("workers")
+	scanTimeout, _ := cmd.Flags().GetDuration("scan-timeout")
 	srURL, _ := cmd.Flags().GetString("sr-url")
 	srAPIKey, _ := cmd.Flags().GetString("sr-api-key")
 	srAPISecret, _ := cmd.Flags().GetString("sr-api-secret")
@@ -31,6 +33,9 @@ func runScan(cmd *cobra.Command, _ []string) error {
 	}
 	if workers > 100 {
 		workers = 100
+	}
+	if scanTimeout <= 0 {
+		return errors.New("--scan-timeout must be positive")
 	}
 
 	// Validate scan-specific flags
@@ -115,7 +120,7 @@ func runScan(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Scan topics for active schema IDs
-	activeSchemas, failedTopics, err := scanTopicsForActiveSchemas(topicsWithCluster, platform, ctx, workers)
+	activeSchemas, failedTopics, err := scanTopicsForActiveSchemas(topicsWithCluster, platform, ctx, workers, scanTimeout)
 	if err != nil {
 		return err
 	}
@@ -312,7 +317,7 @@ type scanResult struct {
 // failures do not abort the run; callers must treat schemas tied to the returned
 // failedTopics as unverified. A non-nil error is only returned for setup
 // failures that prevent scanning entirely (e.g. cluster endpoint resolution).
-func scanTopicsForActiveSchemas(topics []pkg.TopicWithClusterInfo, platform pkg.Platform, ctx *pkg.Context, workers int) (map[int32]int, []string, error) {
+func scanTopicsForActiveSchemas(topics []pkg.TopicWithClusterInfo, platform pkg.Platform, ctx *pkg.Context, workers int, scanTimeout time.Duration) (map[int32]int, []string, error) {
 	if len(topics) == 0 {
 		return make(map[int32]int), nil, nil
 	}
@@ -358,7 +363,7 @@ func scanTopicsForActiveSchemas(topics []pkg.TopicWithClusterInfo, platform pkg.
 			}
 			defer consumer.Close()
 
-			topicSchemas, err := pkg.ScanActiveSchemas(consumer, t.Topic)
+			topicSchemas, err := pkg.ScanActiveSchemas(consumer, t.Topic, scanTimeout)
 			results <- scanResult{schemas: topicSchemas, err: err, topic: t.Topic, cluster: t.ClusterID}
 		}(topic)
 	}
@@ -448,6 +453,7 @@ file that can be passed to the delete command.`,
 	scanCmd.Flags().Bool("all-topics", false, "Scan all topics across all clusters.")
 	scanCmd.Flags().String("context", "", "Schema context to scope operations to (e.g., 'staging').")
 	scanCmd.Flags().Int("workers", 25, "Number of concurrent topic scanners.")
+	scanCmd.Flags().Duration("scan-timeout", 5*time.Minute, "Per-topic scan deadline; topics exceeding it are marked unverified and excluded from deletion.")
 	scanCmd.Flags().String("output", "", "Path to write manifest file.")
 	scanCmd.Flags().String("sr-url", "", "Schema Registry URL (enables reference checking for Cloud).")
 	scanCmd.Flags().String("sr-api-key", "", "Schema Registry API key (for reference checking).")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -42,4 +43,27 @@ func TestMergeActiveSchemas_AllFail(t *testing.T) {
 	// must instead be protected via the failedTopics path.
 	req.Empty(active)
 	req.NotNil(active)
+}
+
+func TestMergeActiveSchemas_DedupsFailuresAcrossClusters(t *testing.T) {
+	req := require.New(t)
+	// Same topic name fails in two clusters; it should appear once, first-seen order.
+	_, failed := mergeActiveSchemas([]scanResult{
+		{topic: "orders", cluster: "lkc-1", err: errors.New("boom")},
+		{topic: "payments", cluster: "lkc-1", err: errors.New("boom")},
+		{topic: "orders", cluster: "lkc-2", err: errors.New("boom")},
+	})
+	req.Equal([]string{"orders", "payments"}, failed)
+}
+
+func TestRunScan_RejectsNonPositiveTimeout(t *testing.T) {
+	req := require.New(t)
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"scan", "--all-subjects", "--scan-timeout=0"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	req.Error(err)
+	req.Contains(err.Error(), "scan-timeout must be positive")
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeActiveSchemas_AllSucceed(t *testing.T) {
+	req := require.New(t)
+	active, failed := mergeActiveSchemas([]scanResult{
+		{topic: "a", schemas: map[int32]int{1: 2, 2: 1}},
+		{topic: "b", schemas: map[int32]int{2: 2, 3: 2}},
+	})
+	req.Empty(failed)
+	// Schema 2 is KEYONLY(1) in a and VALUEONLY(2) in b -> OR-merged to 3.
+	req.Equal(map[int32]int{1: 2, 2: 3, 3: 2}, active)
+}
+
+func TestMergeActiveSchemas_CollectsAllFailures(t *testing.T) {
+	req := require.New(t)
+	active, failed := mergeActiveSchemas([]scanResult{
+		{topic: "a", schemas: map[int32]int{1: 2}},
+		{topic: "b", err: errors.New("auth error")},
+		{topic: "c", err: errors.New("broker down")},
+	})
+	// All failures are reported, not just the first.
+	req.ElementsMatch([]string{"b", "c"}, failed)
+	// Successful topics still contribute their schemas.
+	req.Equal(map[int32]int{1: 2}, active)
+}
+
+func TestMergeActiveSchemas_AllFail(t *testing.T) {
+	req := require.New(t)
+	active, failed := mergeActiveSchemas([]scanResult{
+		{topic: "a", err: errors.New("boom")},
+		{topic: "b", err: errors.New("boom")},
+	})
+	req.ElementsMatch([]string{"a", "b"}, failed)
+	// No schema is active, so nothing is protected by activity — every subject
+	// must instead be protected via the failedTopics path.
+	req.Empty(active)
+	req.NotNil(active)
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -56,6 +56,19 @@ func TestMergeActiveSchemas_DedupsFailuresAcrossClusters(t *testing.T) {
 	req.Equal([]string{"orders", "payments"}, failed)
 }
 
+func TestFailIfUnverified(t *testing.T) {
+	req := require.New(t)
+	// No unverified topics: deletion proceeds regardless of the flag.
+	req.NoError(failIfUnverified(nil, false))
+	req.NoError(failIfUnverified([]string{}, false))
+
+	// Unverified topics present: refuse by default, allow with the flag.
+	err := failIfUnverified([]string{"orders"}, false)
+	req.Error(err)
+	req.Contains(err.Error(), "allow-unverified")
+	req.NoError(failIfUnverified([]string{"orders"}, true))
+}
+
 func TestRunScan_RejectsNonPositiveTimeout(t *testing.T) {
 	req := require.New(t)
 	cmd := newRootCmd()

--- a/pkg/consumer.go
+++ b/pkg/consumer.go
@@ -28,20 +28,17 @@ func CreateConsumerFromConfig(ccfg *kafka.ConfigMap) (*kafka.Consumer, error) {
 
 // ScanActiveSchemas scans all messages in a topic and extracts schema IDs
 // from both the magic byte prefix in payloads AND from message headers
-// (for topics using HeaderSchemaIdSerializer).
-func ScanActiveSchemas(consumer *kafka.Consumer, topic string) (map[int32]int, error) {
-	return scanActiveSchemas(consumer, topic)
+// (for topics using HeaderSchemaIdSerializer). timeout caps the time spent on
+// the topic; exceeding it returns an error so the caller treats the topic as
+// unscanned rather than as fully scanned.
+func ScanActiveSchemas(consumer *kafka.Consumer, topic string, timeout time.Duration) (map[int32]int, error) {
+	return scanActiveSchemas(consumer, topic, timeout)
 }
 
 // scanPollTimeoutMs is how long each Poll waits for a message or EOF event.
-// scanDeadline caps the total time spent on a single topic as a backstop in
-// case partition EOF is never reported.
-const (
-	scanPollTimeoutMs = 5000
-	scanDeadline      = 5 * time.Minute
-)
+const scanPollTimeoutMs = 5000
 
-func scanActiveSchemas(consumer *kafka.Consumer, topic string) (map[int32]int, error) {
+func scanActiveSchemas(consumer *kafka.Consumer, topic string, timeout time.Duration) (map[int32]int, error) {
 	activeSchemas := make(map[int32]int)
 	metadata, err := consumer.GetMetadata(&topic, false, 5000)
 	if err != nil {
@@ -85,14 +82,15 @@ func scanActiveSchemas(consumer *kafka.Consumer, topic string) (map[int32]int, e
 	// requires enable.partition.eof=true on the consumer config.
 	//
 	// The deadline backstops the case where EOF is never reported (e.g. a
-	// partition stuck behind a persistent non-fatal error). It returns an error
-	// so the caller marks the topic unverified instead of mistaking an
-	// incomplete scan for a complete one and deleting in-use schemas.
-	deadline := time.Now().Add(scanDeadline)
+	// partition stuck behind a persistent non-fatal error) and bounds the time
+	// spent on a very large topic. It returns an error so the caller marks the
+	// topic unverified instead of mistaking an incomplete scan for a complete
+	// one and deleting in-use schemas.
+	deadline := time.Now().Add(timeout)
 	eofPartitions := make(map[int32]bool)
 	for !allPartitionsReachedEOF(eofPartitions, numPartitions) {
 		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("scan deadline exceeded after %s", scanDeadline)
+			return nil, fmt.Errorf("scan deadline exceeded after %s", timeout)
 		}
 		if err := handlePollEvent(consumer.Poll(scanPollTimeoutMs), topic, activeSchemas, eofPartitions); err != nil {
 			return nil, err

--- a/pkg/consumer.go
+++ b/pkg/consumer.go
@@ -88,11 +88,12 @@ func scanActiveSchemas(consumer *kafka.Consumer, topic string, timeout time.Dura
 	// one and deleting in-use schemas.
 	deadline := time.Now().Add(timeout)
 	eofPartitions := make(map[int32]bool)
+	loggedErrs := make(map[kafka.ErrorCode]bool)
 	for !allPartitionsReachedEOF(eofPartitions, numPartitions) {
 		if time.Now().After(deadline) {
 			return nil, fmt.Errorf("scan deadline exceeded after %s", timeout)
 		}
-		if err := handlePollEvent(consumer.Poll(scanPollTimeoutMs), topic, activeSchemas, eofPartitions); err != nil {
+		if err := handlePollEvent(consumer.Poll(scanPollTimeoutMs), topic, activeSchemas, eofPartitions, loggedErrs); err != nil {
 			return nil, err
 		}
 	}
@@ -100,10 +101,10 @@ func scanActiveSchemas(consumer *kafka.Consumer, topic string, timeout time.Dura
 	return activeSchemas, nil
 }
 
-// handlePollEvent records schema IDs from a polled message and tracks partitions
-// that have reached EOF. It returns an error only for a fatal kafka.Error;
-// non-fatal errors are logged and skipped, and a nil event (poll timeout) is a no-op.
-func handlePollEvent(event kafka.Event, topic string, activeSchemas map[int32]int, eofPartitions map[int32]bool) error {
+// handlePollEvent records schema IDs from a message and marks partitions that
+// reached EOF. It errors only on a fatal kafka.Error; a non-fatal error is
+// logged once per distinct code, and a nil event (poll timeout) is a no-op.
+func handlePollEvent(event kafka.Event, topic string, activeSchemas map[int32]int, eofPartitions map[int32]bool, loggedErrs map[kafka.ErrorCode]bool) error {
 	switch e := event.(type) {
 	case *kafka.Message:
 		extractSchemaIDFromPayload(e.Value, VALUEONLY, activeSchemas)
@@ -115,7 +116,10 @@ func handlePollEvent(event kafka.Event, topic string, activeSchemas map[int32]in
 		if e.IsFatal() {
 			return e
 		}
-		fmt.Printf("%swarning: topic %s: %v%s\n", YELLOW, topic, e, RESET)
+		if !loggedErrs[e.Code()] {
+			loggedErrs[e.Code()] = true
+			fmt.Printf("%swarning: topic %s: %v%s\n", YELLOW, topic, e, RESET)
+		}
 	}
 	return nil
 }

--- a/pkg/consumer.go
+++ b/pkg/consumer.go
@@ -33,80 +33,93 @@ func ScanActiveSchemas(consumer *kafka.Consumer, topic string) (map[int32]int, e
 	return scanActiveSchemas(consumer, topic)
 }
 
+// scanPollTimeoutMs is how long each Poll waits for a message or EOF event.
+// scanDeadline caps the total time spent on a single topic as a backstop in
+// case partition EOF is never reported.
+const (
+	scanPollTimeoutMs = 5000
+	scanDeadline      = 5 * time.Minute
+)
+
 func scanActiveSchemas(consumer *kafka.Consumer, topic string) (map[int32]int, error) {
 	activeSchemas := make(map[int32]int)
 	metadata, err := consumer.GetMetadata(&topic, false, 5000)
 	if err != nil {
 		return nil, err
 	}
-	DesiredNumPartitions := int32(len(metadata.Topics[topic].Partitions))
-	var tpl []kafka.TopicPartition
-	var topicName = topic
-	for i := int32(0); i < DesiredNumPartitions; i++ {
+	numPartitions := int32(len(metadata.Topics[topic].Partitions))
+	if numPartitions == 0 {
+		return nil, fmt.Errorf("no partition metadata returned (topic may not exist)")
+	}
+
+	topicName := topic
+	tpl := make([]kafka.TopicPartition, 0, numPartitions)
+	var totalMsg int64
+	for i := int32(0); i < numPartitions; i++ {
+		low, high, err := consumer.QueryWatermarkOffsets(topic, i, 10000)
+		if err != nil {
+			return nil, err
+		}
+		totalMsg += high - low
 		tpl = append(tpl, kafka.TopicPartition{
 			Topic:     &topicName,
 			Partition: i,
 			Offset:    kafka.OffsetBeginning,
 		})
 	}
-	err = consumer.Assign(tpl)
-	if err != nil {
-		return nil, err
-	}
-
-	var totalMsg int64 = 0
-	endOffsets := make(map[int32]kafka.Offset)
-	offsets := make(map[int32]kafka.Offset)
-	for i := int32(0); i < DesiredNumPartitions; i++ {
-		low, high, err := consumer.QueryWatermarkOffsets(topic, i, 10000)
-		if err != nil {
-			return nil, err
-		}
-		endOffsets[i] = kafka.Offset(high) - 1
-		offsets[i] = kafka.Offset(low) - 1
-		totalMsg += high - low
-	}
 
 	if totalMsg == 0 {
-		fmt.Println("No messages found, skipping...")
+		fmt.Printf("Topic %s: no messages found, skipping.\n", topic)
 		return activeSchemas, nil
 	}
 
-	deadline := time.Now().Add(5 * time.Minute) // per-topic scan deadline
-	consecutiveTimeouts := 0
-	maxConsecutiveTimeouts := 3
+	if err := consumer.Assign(tpl); err != nil {
+		return nil, err
+	}
 
-	for !checkIfReachesOffsets(endOffsets, offsets, DesiredNumPartitions) {
+	// Terminate when every partition reports EOF rather than by comparing the
+	// last consumed offset to the high watermark. The offset just below the
+	// watermark can be a transaction control record or removed by compaction;
+	// such offsets are never delivered to the consumer, so an offset comparison
+	// would never reach the watermark and the scan would hang. Partition EOF
+	// requires enable.partition.eof=true on the consumer config.
+	//
+	// The deadline backstops the case where EOF is never reported (e.g. a
+	// partition stuck behind a persistent non-fatal error). It returns an error
+	// so the caller marks the topic unverified instead of mistaking an
+	// incomplete scan for a complete one and deleting in-use schemas.
+	deadline := time.Now().Add(scanDeadline)
+	eofPartitions := make(map[int32]bool)
+	for !allPartitionsReachedEOF(eofPartitions, numPartitions) {
 		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("topic %s: scan deadline exceeded (5 minutes)", topic)
+			return nil, fmt.Errorf("scan deadline exceeded after %s", scanDeadline)
 		}
-
-		msg, err := consumer.ReadMessage(10 * time.Second)
-		if err != nil {
-			// ReadMessage timeout is not fatal — it means no message available within the timeout
-			kafkaErr, ok := err.(kafka.Error)
-			if ok && kafkaErr.Code() == kafka.ErrTimedOut {
-				consecutiveTimeouts++
-				if consecutiveTimeouts >= maxConsecutiveTimeouts {
-					// After 3 consecutive timeouts (30s), assume we've read everything available
-					break
-				}
-				continue
-			}
+		if err := handlePollEvent(consumer.Poll(scanPollTimeoutMs), topic, activeSchemas, eofPartitions); err != nil {
 			return nil, err
 		}
-		consecutiveTimeouts = 0
-		offsets[msg.TopicPartition.Partition] = msg.TopicPartition.Offset
-
-		// Extract schema IDs from payload (magic byte prefix)
-		extractSchemaIDFromPayload(msg.Value, VALUEONLY, activeSchemas)
-		extractSchemaIDFromPayload(msg.Key, KEYONLY, activeSchemas)
-
-		// Extract schema IDs from headers (HeaderSchemaIdSerializer)
-		extractSchemaIDsFromHeaders(msg.Headers, activeSchemas)
 	}
 
 	return activeSchemas, nil
+}
+
+// handlePollEvent records schema IDs from a polled message and tracks partitions
+// that have reached EOF. It returns an error only for a fatal kafka.Error;
+// non-fatal errors are logged and skipped, and a nil event (poll timeout) is a no-op.
+func handlePollEvent(event kafka.Event, topic string, activeSchemas map[int32]int, eofPartitions map[int32]bool) error {
+	switch e := event.(type) {
+	case *kafka.Message:
+		extractSchemaIDFromPayload(e.Value, VALUEONLY, activeSchemas)
+		extractSchemaIDFromPayload(e.Key, KEYONLY, activeSchemas)
+		extractSchemaIDsFromHeaders(e.Headers, activeSchemas)
+	case kafka.PartitionEOF:
+		eofPartitions[e.Partition] = true
+	case kafka.Error:
+		if e.IsFatal() {
+			return e
+		}
+		fmt.Printf("%swarning: topic %s: %v%s\n", YELLOW, topic, e, RESET)
+	}
+	return nil
 }
 
 // extractSchemaIDFromPayload extracts schema ID from the Confluent wire format:
@@ -172,14 +185,9 @@ func parseSchemaIDFromHeaderValue(value []byte) int32 {
 	return 0
 }
 
-func checkIfReachesOffsets(endOffsets, offsets map[int32]kafka.Offset, partitions int32) bool {
+func allPartitionsReachedEOF(eofPartitions map[int32]bool, partitions int32) bool {
 	for i := int32(0); i < partitions; i++ {
-		val, ok := offsets[i]
-		if !ok {
-			val = -1
-		}
-		endVal, _ := endOffsets[i]
-		if val < endVal {
+		if !eofPartitions[i] {
 			return false
 		}
 	}

--- a/pkg/consumer.go
+++ b/pkg/consumer.go
@@ -113,7 +113,7 @@ func handlePollEvent(event kafka.Event, topic string, activeSchemas map[int32]in
 	case kafka.PartitionEOF:
 		eofPartitions[e.Partition] = true
 	case kafka.Error:
-		if e.IsFatal() {
+		if e.IsFatal() || terminalScanErrors[e.Code()] {
 			return e
 		}
 		if !loggedErrs[e.Code()] {
@@ -122,6 +122,17 @@ func handlePollEvent(event kafka.Event, topic string, activeSchemas map[int32]in
 		}
 	}
 	return nil
+}
+
+// terminalScanErrors are auth/authz failures that retrying within the scan
+// cannot resolve, so the topic fails immediately instead of polling until the
+// deadline.
+var terminalScanErrors = map[kafka.ErrorCode]bool{
+	kafka.ErrTopicAuthorizationFailed:   true,
+	kafka.ErrClusterAuthorizationFailed: true,
+	kafka.ErrGroupAuthorizationFailed:   true,
+	kafka.ErrSaslAuthenticationFailed:   true,
+	kafka.ErrAuthentication:             true,
 }
 
 // extractSchemaIDFromPayload extracts schema ID from the Confluent wire format:

--- a/pkg/consumer_test.go
+++ b/pkg/consumer_test.go
@@ -54,6 +54,16 @@ func TestHandlePollEvent_FatalErrorReturned(t *testing.T) {
 	req.Error(err)
 }
 
+func TestHandlePollEvent_TerminalAuthErrorReturned(t *testing.T) {
+	req := require.New(t)
+	for code := range terminalScanErrors {
+		// A non-fatal auth/authz error still terminates the scan (won't resolve on retry).
+		err := handlePollEvent(kafka.NewError(code, "denied", false),
+			"orders", make(map[int32]int), make(map[int32]bool), map[kafka.ErrorCode]bool{})
+		req.Errorf(err, "expected error for code %v", code)
+	}
+}
+
 func TestHandlePollEvent_NonFatalErrorLoggedOncePerCode(t *testing.T) {
 	req := require.New(t)
 	eof := make(map[int32]bool)

--- a/pkg/consumer_test.go
+++ b/pkg/consumer_test.go
@@ -8,15 +8,68 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCompareOffsets(t *testing.T) {
+func TestAllPartitionsReachedEOF(t *testing.T) {
 	req := require.New(t)
-	req.True(checkIfReachesOffsets(map[int32]kafka.Offset{0: kafka.OffsetEnd}, map[int32]kafka.Offset{}, 1))
-	req.True(checkIfReachesOffsets(map[int32]kafka.Offset{0: kafka.OffsetEnd}, map[int32]kafka.Offset{0: 0}, 1))
-	req.False(checkIfReachesOffsets(map[int32]kafka.Offset{0: 0}, map[int32]kafka.Offset{}, 1))
-	req.True(checkIfReachesOffsets(map[int32]kafka.Offset{0: 2}, map[int32]kafka.Offset{0: 2}, 1))
-	req.False(checkIfReachesOffsets(map[int32]kafka.Offset{0: 2}, map[int32]kafka.Offset{0: 1}, 1))
-	req.False(checkIfReachesOffsets(map[int32]kafka.Offset{0: 2, 1: 4}, map[int32]kafka.Offset{0: 1, 1: 4}, 2))
-	req.False(checkIfReachesOffsets(map[int32]kafka.Offset{0: 2, 1: 4}, map[int32]kafka.Offset{0: 1, 1: 4}, 2))
+	// No partitions: vacuously done.
+	req.True(allPartitionsReachedEOF(map[int32]bool{}, 0))
+	// Single partition not yet at EOF.
+	req.False(allPartitionsReachedEOF(map[int32]bool{}, 1))
+	req.False(allPartitionsReachedEOF(map[int32]bool{0: false}, 1))
+	// Single partition at EOF.
+	req.True(allPartitionsReachedEOF(map[int32]bool{0: true}, 1))
+	// Multi-partition: all must be at EOF.
+	req.False(allPartitionsReachedEOF(map[int32]bool{0: true}, 2))
+	req.False(allPartitionsReachedEOF(map[int32]bool{0: true, 1: false}, 2))
+	req.True(allPartitionsReachedEOF(map[int32]bool{0: true, 1: true}, 2))
+}
+
+func TestHandlePollEvent_Message(t *testing.T) {
+	req := require.New(t)
+	active := make(map[int32]int)
+	eof := make(map[int32]bool)
+
+	value := make([]byte, MessageOffset)
+	value[0] = MagicByte
+	binary.BigEndian.PutUint32(value[1:MessageOffset], 7)
+
+	req.NoError(handlePollEvent(&kafka.Message{Value: value}, "orders", active, eof))
+	req.Equal(VALUEONLY, active[7])
+	req.Empty(eof)
+}
+
+func TestHandlePollEvent_PartitionEOF(t *testing.T) {
+	req := require.New(t)
+	active := make(map[int32]int)
+	eof := make(map[int32]bool)
+
+	req.NoError(handlePollEvent(kafka.PartitionEOF{Partition: 2}, "orders", active, eof))
+	req.True(eof[2])
+	req.Empty(active)
+}
+
+func TestHandlePollEvent_FatalErrorReturned(t *testing.T) {
+	req := require.New(t)
+	err := handlePollEvent(kafka.NewError(kafka.ErrAllBrokersDown, "down", true),
+		"orders", make(map[int32]int), make(map[int32]bool))
+	req.Error(err)
+}
+
+func TestHandlePollEvent_NonFatalErrorSkipped(t *testing.T) {
+	req := require.New(t)
+	eof := make(map[int32]bool)
+	err := handlePollEvent(kafka.NewError(kafka.ErrOffsetOutOfRange, "transient", false),
+		"orders", make(map[int32]int), eof)
+	req.NoError(err)
+	req.Empty(eof) // a non-fatal error must not be mistaken for EOF
+}
+
+func TestHandlePollEvent_NilTimeout(t *testing.T) {
+	req := require.New(t)
+	active := make(map[int32]int)
+	eof := make(map[int32]bool)
+	req.NoError(handlePollEvent(nil, "orders", active, eof))
+	req.Empty(active)
+	req.Empty(eof)
 }
 
 func TestExtractSchemaIDFromPayload_Valid(t *testing.T) {

--- a/pkg/consumer_test.go
+++ b/pkg/consumer_test.go
@@ -32,7 +32,7 @@ func TestHandlePollEvent_Message(t *testing.T) {
 	value[0] = MagicByte
 	binary.BigEndian.PutUint32(value[1:MessageOffset], 7)
 
-	req.NoError(handlePollEvent(&kafka.Message{Value: value}, "orders", active, eof))
+	req.NoError(handlePollEvent(&kafka.Message{Value: value}, "orders", active, eof, map[kafka.ErrorCode]bool{}))
 	req.Equal(VALUEONLY, active[7])
 	req.Empty(eof)
 }
@@ -42,7 +42,7 @@ func TestHandlePollEvent_PartitionEOF(t *testing.T) {
 	active := make(map[int32]int)
 	eof := make(map[int32]bool)
 
-	req.NoError(handlePollEvent(kafka.PartitionEOF{Partition: 2}, "orders", active, eof))
+	req.NoError(handlePollEvent(kafka.PartitionEOF{Partition: 2}, "orders", active, eof, map[kafka.ErrorCode]bool{}))
 	req.True(eof[2])
 	req.Empty(active)
 }
@@ -50,24 +50,29 @@ func TestHandlePollEvent_PartitionEOF(t *testing.T) {
 func TestHandlePollEvent_FatalErrorReturned(t *testing.T) {
 	req := require.New(t)
 	err := handlePollEvent(kafka.NewError(kafka.ErrAllBrokersDown, "down", true),
-		"orders", make(map[int32]int), make(map[int32]bool))
+		"orders", make(map[int32]int), make(map[int32]bool), map[kafka.ErrorCode]bool{})
 	req.Error(err)
 }
 
-func TestHandlePollEvent_NonFatalErrorSkipped(t *testing.T) {
+func TestHandlePollEvent_NonFatalErrorLoggedOncePerCode(t *testing.T) {
 	req := require.New(t)
 	eof := make(map[int32]bool)
-	err := handlePollEvent(kafka.NewError(kafka.ErrOffsetOutOfRange, "transient", false),
-		"orders", make(map[int32]int), eof)
-	req.NoError(err)
+	logged := make(map[kafka.ErrorCode]bool)
+	e := kafka.NewError(kafka.ErrOffsetOutOfRange, "transient", false)
+
+	req.NoError(handlePollEvent(e, "orders", make(map[int32]int), eof, logged))
 	req.Empty(eof) // a non-fatal error must not be mistaken for EOF
+	req.True(logged[kafka.ErrOffsetOutOfRange])
+
+	// A repeat of the same code is deduped and still returns no error.
+	req.NoError(handlePollEvent(e, "orders", make(map[int32]int), eof, logged))
 }
 
 func TestHandlePollEvent_NilTimeout(t *testing.T) {
 	req := require.New(t)
 	active := make(map[int32]int)
 	eof := make(map[int32]bool)
-	req.NoError(handlePollEvent(nil, "orders", active, eof))
+	req.NoError(handlePollEvent(nil, "orders", active, eof, map[kafka.ErrorCode]bool{}))
 	req.Empty(active)
 	req.Empty(eof)
 }

--- a/pkg/manifest.go
+++ b/pkg/manifest.go
@@ -23,10 +23,11 @@ func WriteManifest(path string, candidates []DeletionCandidate, opts ManifestOpt
 		Strategy:        opts.Strategy,
 		SRUrl:           opts.SRUrl,
 		Environment:     opts.Environment,
-		Candidates:      candidates,
-		ScannedTopics:   opts.ScannedTopics,
-		ScannedClusters: opts.ScannedClusters,
-		ActiveSchemaIDs: activeIDs,
+		Candidates:       candidates,
+		ScannedTopics:    opts.ScannedTopics,
+		ScannedClusters:  opts.ScannedClusters,
+		ActiveSchemaIDs:  activeIDs,
+		UnverifiedTopics: opts.UnverifiedTopics,
 	}
 
 	data, err := json.MarshalIndent(manifest, "", "  ")
@@ -115,13 +116,14 @@ func GetWarnedCandidates(candidates []DeletionCandidate) []DeletionCandidate {
 
 // ManifestOptions holds metadata for manifest generation.
 type ManifestOptions struct {
-	Platform        string
-	Strategy        string
-	SRUrl           string
-	Environment     string
-	ScannedTopics   []string
-	ScannedClusters []string
-	ActiveSchemaIDs map[int32]int
+	Platform         string
+	Strategy         string
+	SRUrl            string
+	Environment      string
+	ScannedTopics    []string
+	ScannedClusters  []string
+	ActiveSchemaIDs  map[int32]int
+	UnverifiedTopics []string
 }
 
 // ExecuteDeletion performs soft-delete and/or hard-delete on candidates.

--- a/pkg/manifest_test.go
+++ b/pkg/manifest_test.go
@@ -25,11 +25,12 @@ func TestWriteAndReadManifest(t *testing.T) {
 	}
 
 	opts := ManifestOptions{
-		Platform:        "cloud",
-		Strategy:        "topic-name",
-		ScannedTopics:   []string{"orders", "users", "payments"},
-		ScannedClusters: []string{"lkc-123"},
-		ActiveSchemaIDs: map[int32]int{100: VALUEONLY, 300: VALUEONLY},
+		Platform:         "cloud",
+		Strategy:         "topic-name",
+		ScannedTopics:    []string{"orders", "users", "payments"},
+		ScannedClusters:  []string{"lkc-123"},
+		ActiveSchemaIDs:  map[int32]int{100: VALUEONLY, 300: VALUEONLY},
+		UnverifiedTopics: []string{"users"},
 	}
 
 	err := WriteManifest(path, candidates, opts)
@@ -47,6 +48,7 @@ func TestWriteAndReadManifest(t *testing.T) {
 	req.Equal("validateAge", manifest.Candidates[2].Rules.DomainRules[0].Name)
 	req.Len(manifest.ScannedTopics, 3)
 	req.Len(manifest.ScannedClusters, 1)
+	req.Equal([]string{"users"}, manifest.UnverifiedTopics)
 }
 
 func TestReadManifest_MissingSubject(t *testing.T) {

--- a/pkg/platform.go
+++ b/pkg/platform.go
@@ -102,6 +102,7 @@ const (
 	StatusBlockedByMigrationChain CandidateStatus = "blocked_by_migration_chain"
 	StatusBlockedByEncryption     CandidateStatus = "blocked_by_encryption_rules"
 	StatusBlockedByRuleReference  CandidateStatus = "blocked_by_rule_reference"
+	StatusBlockedUnverified       CandidateStatus = "blocked_unverified"
 	StatusWarnHasDomainRules      CandidateStatus = "has_domain_rules"
 	StatusWarnHasMigrationRules   CandidateStatus = "has_migration_rules"
 )
@@ -122,7 +123,7 @@ type DeletionCandidate struct {
 func (c *DeletionCandidate) IsBlocked() bool {
 	switch c.Status {
 	case StatusBlockedByReferences, StatusBlockedByMigrationChain,
-		StatusBlockedByEncryption, StatusBlockedByRuleReference:
+		StatusBlockedByEncryption, StatusBlockedByRuleReference, StatusBlockedUnverified:
 		return true
 	}
 	return false
@@ -142,9 +143,10 @@ type Manifest struct {
 	SRUrl           string              `json:"sr_url,omitempty"`
 	Environment     string              `json:"environment,omitempty"`
 	Candidates      []DeletionCandidate `json:"candidates"`
-	ScannedTopics   []string            `json:"scanned_topics,omitempty"`
-	ScannedClusters []string            `json:"scanned_clusters,omitempty"`
-	ActiveSchemaIDs []int32             `json:"active_schema_ids,omitempty"`
+	ScannedTopics    []string           `json:"scanned_topics,omitempty"`
+	ScannedClusters  []string           `json:"scanned_clusters,omitempty"`
+	ActiveSchemaIDs  []int32            `json:"active_schema_ids,omitempty"`
+	UnverifiedTopics []string           `json:"unverified_topics,omitempty"`
 }
 
 // CPClusterConfig holds configuration for a single CP Kafka cluster.

--- a/pkg/platform_cloud.go
+++ b/pkg/platform_cloud.go
@@ -256,6 +256,11 @@ func (c *CloudPlatform) CreateConsumerConfig(clusterID string, creds Credentials
 	if err := ccfg.SetKey("enable.partition.eof", true); err != nil {
 		return nil, err
 	}
+	// EOF-based scan termination needs partition EOF at the last stable offset;
+	// pin this rather than rely on the librdkafka default.
+	if err := ccfg.SetKey("isolation.level", "read_committed"); err != nil {
+		return nil, err
+	}
 	return ccfg, nil
 }
 

--- a/pkg/platform_cloud.go
+++ b/pkg/platform_cloud.go
@@ -253,6 +253,9 @@ func (c *CloudPlatform) CreateConsumerConfig(clusterID string, creds Credentials
 	if err := ccfg.SetKey("auto.offset.reset", "earliest"); err != nil {
 		return nil, err
 	}
+	if err := ccfg.SetKey("enable.partition.eof", true); err != nil {
+		return nil, err
+	}
 	return ccfg, nil
 }
 

--- a/pkg/platform_cp.go
+++ b/pkg/platform_cp.go
@@ -339,6 +339,11 @@ func (cp *CPPlatform) CreateConsumerConfig(clusterID string, creds Credentials) 
 	if err = configMap.SetKey("enable.partition.eof", true); err != nil {
 		return nil, err
 	}
+	// EOF-based scan termination needs partition EOF at the last stable offset;
+	// pin this rather than rely on the librdkafka default.
+	if err = configMap.SetKey("isolation.level", "read_committed"); err != nil {
+		return nil, err
+	}
 	return configMap, nil
 }
 

--- a/pkg/platform_cp.go
+++ b/pkg/platform_cp.go
@@ -336,6 +336,9 @@ func (cp *CPPlatform) CreateConsumerConfig(clusterID string, creds Credentials) 
 	if err = configMap.SetKey("auto.offset.reset", "earliest"); err != nil {
 		return nil, err
 	}
+	if err = configMap.SetKey("enable.partition.eof", true); err != nil {
+		return nil, err
+	}
 	return configMap, nil
 }
 

--- a/pkg/safety.go
+++ b/pkg/safety.go
@@ -77,7 +77,11 @@ func MarkUnverified(candidates []DeletionCandidate, unverifiedSubjects map[strin
 	}
 	for i := range candidates {
 		if unverifiedSubjects[candidates[i].Subject] {
-			candidates[i].Status = StatusBlockedUnverified
+			// Keep an already-blocked candidate's more specific status; only
+			// safe/warned ones need upgrading to blocked.
+			if !candidates[i].IsBlocked() {
+				candidates[i].Status = StatusBlockedUnverified
+			}
 			candidates[i].BlockReasons = append(candidates[i].BlockReasons,
 				"Topic could not be scanned; schema usage could not be verified")
 		}

--- a/pkg/safety.go
+++ b/pkg/safety.go
@@ -67,6 +67,24 @@ func AnalyzeCandidates(schemas []SchemaInfo, activeSchemas map[int32]int, platfo
 	return candidates, nil
 }
 
+// MarkUnverified blocks candidates whose subject belongs to a topic that could
+// not be scanned. Active schema IDs are tracked globally across all topics, so a
+// schema seen only in an unscanned topic would otherwise look unused; blocking
+// these subjects ensures such schemas are never deleted.
+func MarkUnverified(candidates []DeletionCandidate, unverifiedSubjects map[string]bool) []DeletionCandidate {
+	if len(unverifiedSubjects) == 0 {
+		return candidates
+	}
+	for i := range candidates {
+		if unverifiedSubjects[candidates[i].Subject] {
+			candidates[i].Status = StatusBlockedUnverified
+			candidates[i].BlockReasons = append(candidates[i].BlockReasons,
+				"Topic could not be scanned; schema usage could not be verified")
+		}
+	}
+	return candidates
+}
+
 func checkReferences(candidates []DeletionCandidate, candidateIDs map[int]bool, platform Platform) []DeletionCandidate {
 	for i := range candidates {
 		refs, err := platform.GetReferencedBy(candidates[i].Subject, candidates[i].Version)

--- a/pkg/strategy.go
+++ b/pkg/strategy.go
@@ -30,6 +30,68 @@ func VerifySubjectForStrategy(subject string, strategy string) bool {
 	}
 }
 
+// SubjectsForFailedTopics returns the subset of allSubjects that resolve to one
+// of failedTopics under the given naming strategy. These subjects could not have
+// their usage verified and must be protected from deletion.
+//
+// For record-name, subjects are not tied to topics by name and active schema IDs
+// are tracked globally, so any unscannable topic leaves every subject unverifiable.
+func SubjectsForFailedTopics(failedTopics, allSubjects, allTopics []string, strategy string) map[string]bool {
+	unverified := make(map[string]bool)
+	if len(failedTopics) == 0 {
+		return unverified
+	}
+
+	failedSet := make(map[string]bool, len(failedTopics))
+	for _, t := range failedTopics {
+		failedSet[t] = true
+	}
+
+	switch strategy {
+	case "record-name":
+		for _, s := range allSubjects {
+			unverified[s] = true
+		}
+	case "topic-record-name":
+		sortedTopics := topicsByDescendingLength(allTopics)
+		for _, s := range allSubjects {
+			if t, ok := longestPrefixTopic(GetRawSubject(s), sortedTopics); ok && failedSet[t] {
+				unverified[s] = true
+			}
+		}
+	default: // topic-name
+		for _, s := range allSubjects {
+			if failedSet[TopicFromSubject(s)] {
+				unverified[s] = true
+			}
+		}
+	}
+	return unverified
+}
+
+// topicsByDescendingLength returns a copy of topics sorted longest-first, so a
+// prefix scan finds the most specific match first (TopicRecordNameStrategy).
+func topicsByDescendingLength(topics []string) []string {
+	sorted := make([]string, len(topics))
+	copy(sorted, topics)
+	sort.Slice(sorted, func(i, j int) bool {
+		return len(sorted[i]) > len(sorted[j])
+	})
+	return sorted
+}
+
+// longestPrefixTopic returns the longest topic in sortedTopics (which must be
+// sorted longest-first) that is a prefix of raw followed by '-', matching how
+// TopicRecordNameStrategy names subjects as "<topic>-<record>".
+func longestPrefixTopic(raw string, sortedTopics []string) (string, bool) {
+	for _, t := range sortedTopics {
+		if strings.HasPrefix(raw, t+"-") {
+			return t, true
+		}
+	}
+	return "", false
+}
+
 // ResolveTopics determines which topics to scan based on the naming strategy.
 func ResolveTopics(subjects []string, strategy string, explicitTopics []string, scanAllTopics bool, platform Platform, clusters []string) ([]TopicWithClusterInfo, error) {
 	if len(explicitTopics) > 0 {
@@ -121,25 +183,17 @@ func resolveTopicRecordName(subjects []string, platform Platform, clusters []str
 		}
 	}
 
-	// Sort topics by length descending for longest-prefix matching
-	sortedTopics := make([]string, 0, len(allTopics))
+	topicNames := make([]string, 0, len(allTopics))
 	for t := range allTopics {
-		sortedTopics = append(sortedTopics, t)
+		topicNames = append(topicNames, t)
 	}
-	sort.Slice(sortedTopics, func(i, j int) bool {
-		return len(sortedTopics[i]) > len(sortedTopics[j])
-	})
+	sortedTopics := topicsByDescendingLength(topicNames)
 
 	// Match subjects to topics
 	matchedTopics := make(map[string]bool)
 	for _, subject := range subjects {
-		rawSubject := GetRawSubject(subject)
-
-		for _, topic := range sortedTopics {
-			if strings.HasPrefix(rawSubject, topic+"-") {
-				matchedTopics[topic] = true
-				break // Longest match found
-			}
+		if topic, ok := longestPrefixTopic(GetRawSubject(subject), sortedTopics); ok {
+			matchedTopics[topic] = true
 		}
 	}
 

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -10,9 +10,10 @@ const (
 
 	Confluent = "confluent"
 
-	GREEN = "\033[32m"
-	RED   = "\033[31m"
-	RESET = "\033[0m"
+	GREEN  = "\033[32m"
+	RED    = "\033[31m"
+	YELLOW = "\033[33m"
+	RESET  = "\033[0m"
 
 	KEYONLY   = 1
 	VALUEONLY = 2

--- a/pkg/unverified_test.go
+++ b/pkg/unverified_test.go
@@ -1,0 +1,76 @@
+package pkg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubjectsForFailedTopics_NoFailures(t *testing.T) {
+	req := require.New(t)
+	got := SubjectsForFailedTopics(nil, []string{"orders-value"}, []string{"orders"}, "topic-name")
+	req.Empty(got)
+}
+
+func TestSubjectsForFailedTopics_TopicName(t *testing.T) {
+	req := require.New(t)
+	subjects := []string{"orders-value", "orders-key", "payments-value"}
+	got := SubjectsForFailedTopics([]string{"orders"}, subjects, []string{"orders", "payments"}, "topic-name")
+	req.Equal(map[string]bool{"orders-value": true, "orders-key": true}, got)
+}
+
+func TestSubjectsForFailedTopics_TopicNameWithContext(t *testing.T) {
+	req := require.New(t)
+	subjects := []string{":.ctx:orders-value", "payments-value"}
+	got := SubjectsForFailedTopics([]string{"orders"}, subjects, nil, "topic-name")
+	req.Equal(map[string]bool{":.ctx:orders-value": true}, got)
+}
+
+func TestSubjectsForFailedTopics_DefaultStrategyTreatedAsTopicName(t *testing.T) {
+	req := require.New(t)
+	subjects := []string{"orders-value", "orders-key", "payments-value"}
+	// An empty/unknown strategy falls through to topic-name behavior, matching
+	// ResolveTopics which defaults an unset strategy to topic-name.
+	got := SubjectsForFailedTopics([]string{"orders"}, subjects, []string{"orders", "payments"}, "")
+	req.Equal(map[string]bool{"orders-value": true, "orders-key": true}, got)
+}
+
+func TestSubjectsForFailedTopics_RecordNameBlocksAll(t *testing.T) {
+	req := require.New(t)
+	subjects := []string{"com.example.Order", "com.example.Payment"}
+	// Subjects aren't tied to topics by name, so any failure taints every subject.
+	got := SubjectsForFailedTopics([]string{"some-topic"}, subjects, []string{"some-topic"}, "record-name")
+	req.Equal(map[string]bool{"com.example.Order": true, "com.example.Payment": true}, got)
+}
+
+func TestSubjectsForFailedTopics_TopicRecordNameLongestPrefix(t *testing.T) {
+	req := require.New(t)
+	topics := []string{"orders", "orders-eu"}
+	subjects := []string{"orders-eu-com.example.Order", "orders-com.example.Payment"}
+	// Only the subject whose longest-prefix topic ("orders-eu") failed is unverified.
+	got := SubjectsForFailedTopics([]string{"orders-eu"}, subjects, topics, "topic-record-name")
+	req.Equal(map[string]bool{"orders-eu-com.example.Order": true}, got)
+}
+
+func TestMarkUnverified(t *testing.T) {
+	req := require.New(t)
+	candidates := []DeletionCandidate{
+		{Subject: "orders-value", Version: "1", SchemaID: "10", Status: StatusSafe},
+		{Subject: "payments-value", Version: "1", SchemaID: "20", Status: StatusSafe},
+	}
+	got := MarkUnverified(candidates, map[string]bool{"orders-value": true})
+
+	req.Equal(StatusBlockedUnverified, got[0].Status)
+	req.True(got[0].IsBlocked())
+	req.NotEmpty(got[0].BlockReasons)
+	// Untouched subject stays safe.
+	req.Equal(StatusSafe, got[1].Status)
+	req.False(got[1].IsBlocked())
+}
+
+func TestMarkUnverified_NoUnverified(t *testing.T) {
+	req := require.New(t)
+	candidates := []DeletionCandidate{{Subject: "orders-value", Status: StatusSafe}}
+	got := MarkUnverified(candidates, nil)
+	req.Equal(StatusSafe, got[0].Status)
+}

--- a/pkg/unverified_test.go
+++ b/pkg/unverified_test.go
@@ -68,6 +68,31 @@ func TestMarkUnverified(t *testing.T) {
 	req.False(got[1].IsBlocked())
 }
 
+func TestMarkUnverified_PreservesSpecificBlockStatus(t *testing.T) {
+	req := require.New(t)
+	candidates := []DeletionCandidate{
+		{Subject: "orders-value", Status: StatusBlockedByReferences,
+			BlockReasons: []string{"Referenced by active schema IDs: [300]"}},
+	}
+	got := MarkUnverified(candidates, map[string]bool{"orders-value": true})
+
+	req.Equal(StatusBlockedByReferences, got[0].Status)
+	req.Len(got[0].BlockReasons, 2)
+	req.Contains(got[0].BlockReasons[1], "could not be scanned")
+}
+
+func TestMarkUnverified_UpgradesWarnedToBlocked(t *testing.T) {
+	req := require.New(t)
+	candidates := []DeletionCandidate{
+		{Subject: "orders-value", Status: StatusWarnHasDomainRules},
+	}
+	got := MarkUnverified(candidates, map[string]bool{"orders-value": true})
+
+	// A warned candidate is deletable-with-confirmation, so it must be blocked.
+	req.Equal(StatusBlockedUnverified, got[0].Status)
+	req.True(got[0].IsBlocked())
+}
+
 func TestMarkUnverified_NoUnverified(t *testing.T) {
 	req := require.New(t)
 	candidates := []DeletionCandidate{{Subject: "orders-value", Status: StatusSafe}}

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -43,10 +43,15 @@ func VerifySubject(subject string) bool {
 	return IsValueSchema(subject) || IsKeySchema(subject)
 }
 
-// TopicFromSubject strips the context prefix and the -value/-key suffix to
-// recover the topic name for a TopicNameStrategy subject.
+// TopicFromSubject recovers the topic for a TopicNameStrategy subject by
+// stripping the context prefix and exactly one -value/-key suffix. Removing only
+// one suffix keeps topics whose names end in -key/-value intact.
 func TopicFromSubject(subject string) string {
-	return strings.TrimSuffix(strings.TrimSuffix(GetRawSubject(subject), "-value"), "-key")
+	raw := GetRawSubject(subject)
+	if t := strings.TrimSuffix(raw, "-value"); t != raw {
+		return t
+	}
+	return strings.TrimSuffix(raw, "-key")
 }
 
 func ExtractTopicFromSubject(subjects []string) []string {

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -43,12 +43,17 @@ func VerifySubject(subject string) bool {
 	return IsValueSchema(subject) || IsKeySchema(subject)
 }
 
+// TopicFromSubject strips the context prefix and the -value/-key suffix to
+// recover the topic name for a TopicNameStrategy subject.
+func TopicFromSubject(subject string) string {
+	return strings.TrimSuffix(strings.TrimSuffix(GetRawSubject(subject), "-value"), "-key")
+}
+
 func ExtractTopicFromSubject(subjects []string) []string {
 	seen := make(map[string]bool)
 	var topics []string
 	for _, subject := range subjects {
-		rawSubject := GetRawSubject(subject)
-		topic := strings.TrimSuffix(strings.TrimSuffix(rawSubject, "-value"), "-key")
+		topic := TopicFromSubject(subject)
 		if !seen[topic] {
 			seen[topic] = true
 			topics = append(topics, topic)

--- a/pkg/utils_test.go
+++ b/pkg/utils_test.go
@@ -38,6 +38,16 @@ func TestExtractTopicFromSubject(t *testing.T) {
 	req.Equal([]string{"orders", "payments", "users"}, ExtractTopicFromSubject(subjects))
 }
 
+func TestTopicFromSubject(t *testing.T) {
+	req := require.New(t)
+	req.Equal("orders", TopicFromSubject("orders-value"))
+	req.Equal("orders", TopicFromSubject("orders-key"))
+	req.Equal("orders", TopicFromSubject(":.mycontext:orders-value"))
+	// Topic names that themselves end in -key/-value: only one suffix is stripped.
+	req.Equal("orders-key", TopicFromSubject("orders-key-value"))
+	req.Equal("orders-value", TopicFromSubject("orders-value-key"))
+}
+
 func TestIsValidChoice(t *testing.T) {
 	req := require.New(t)
 	validCandidates := []string{


### PR DESCRIPTION
**Jira:** [DGS-24644](https://confluentinc.atlassian.net/browse/DGS-24644)

## What

Fixes a customer-reported scan hang and hardens `scan`/`delete` against incomplete scans.

- **Scan no longer hangs on offset gaps.** Terminate on partition EOF (`enable.partition.eof=true`, `isolation.level=read_committed`) instead of comparing the last offset to the high watermark — a transaction control record or compaction can leave a gap the old comparison never crossed, hanging forever.
- **An unscannable topic no longer aborts the whole run, and can't cause a bad delete.** Scanned topics still produce a partial manifest; subjects tied to a failed topic are marked `blocked_unverified` and excluded from deletion.
- **`--scan-timeout` (default 5m)** makes the per-topic deadline configurable for large topics.
- **Fail fast on auth/authz errors** (topic/cluster/group authz, SASL, authentication) instead of polling until the deadline.
- **`delete` refuses a manifest with unverified topics** unless `--allow-unverified` is passed (deliberately *not* bypassed by `--force`).

## Key safety property

Any scan deadline/error returns an *error*, so "scanned successfully" always means "fully scanned" — an incomplete scan can never make an in-use schema look unused and get deleted.

`go build`, `go vet`, `go test ./...` all pass.


[DGS-24644]: https://confluentinc.atlassian.net/browse/DGS-24644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ